### PR TITLE
Fix window resize icon placement

### DIFF
--- a/game.html
+++ b/game.html
@@ -21,6 +21,7 @@
       width: 20%;
     }
     .cell {
+      position: relative;
       border: 1px solid #333;
       padding: 5px;
       font-size: 14px;
@@ -34,6 +35,8 @@
     }
     .laser, .missile {
       position: absolute;
+      top: 0px;
+      left: -1px;
       width: 50px; /* Smaller size */
       height: 50px; /* Smaller size */
       border-radius: 50%;
@@ -114,7 +117,7 @@
   <div id="game-container">
     <div id="status"></div>
     <div id="round-info">
-      <span>Rounds Left: <strong id="rounds-left">5</strong></span> | 
+      <span>Rounds Left: <strong id="rounds-left">5</strong></span> |
       <span>Missile Fuel: <strong id="missile-fuel">6</strong></span>
     </div>
     <div class="board-visual" id="game-board"></div>

--- a/game.js
+++ b/game.js
@@ -275,23 +275,19 @@ function recordAction(state, fuelBurned, laserGuess) {
   const newMissileIcon = document.createElement("div");
   newMissileIcon.className = "missile";
   newMissileIcon.textContent = "🚀";
-  newMissileIcon.style.top = missileCell.offsetTop + "px";
-  newMissileIcon.style.left = missileCell.offsetLeft + "px";
-  gameBoard.appendChild(newMissileIcon);
+  missileCell.appendChild(newMissileIcon);
 
   // Create new laser icon
   const newLaserIcon = document.createElement("div");
   newLaserIcon.className = "laser";
-  newLaserIcon.style.top = laserCell.offsetTop + "px";
-  newLaserIcon.style.left = laserCell.offsetLeft + "px";
-  gameBoard.appendChild(newLaserIcon);
+  laserCell.appendChild(newLaserIcon);
 
   // Offset icons if they share the same cell
   if (missilePos === laserPos) {
-    newMissileIcon.style.top = (missileCell.offsetTop + 5) + "px"; // Offset by 5px
-    newMissileIcon.style.left = (missileCell.offsetLeft + 5) + "px"; // Offset by 5px
-    newLaserIcon.style.top = (laserCell.offsetTop - 5) + "px"; // Offset by -5px
-    newLaserIcon.style.left = (laserCell.offsetLeft - 5) + "px"; // Offset by -5px
+    newMissileIcon.style.top = "6px"; // Offset by 5px
+    newMissileIcon.style.left = "6px"; // Offset by 5px
+    newLaserIcon.style.top = "-6px"; // Offset by -5px
+    newLaserIcon.style.left = "-6px"; // Offset by -5px
   }
 }
 


### PR DESCRIPTION
I have made the icons relative to cells so they resize with the board. The positioning is approximate at best but roughly emulates the previous placement.